### PR TITLE
Compatibility fix for node 5.5.0

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,5 +1,6 @@
 var http = require('http')
   , Service = require('./service')
+  , url = require('url')
 
 module.exports = function getAgent (options) {
 
@@ -12,6 +13,10 @@ module.exports = function getAgent (options) {
   // All we're doing is asynchronously retrieving a spec (host + port) given the
   // virtual host, and passing that to a real HTTP agent.
   Agent.prototype.addRequest = function (req, service) {
+		// Fix for node 5.5.0+ where service contains options instead of hostname
+    if (service.href) {
+      service = url.parse(service.href).hostname;
+    }
     var self = this;
     if (!req.listeners('spec').length) {
       req.on('spec', function (spec) {


### PR DESCRIPTION
This fix allows to use amino (redis) with node 5.5.0.
It stopped working due to internal changes in http module.

Node 0.10.32
http.js:1420
self.agent.addRequest(self, host, port, options.localAddress);

Node 5.5.0
_http_client:137
self.agent.addRequest(self, options);
